### PR TITLE
collapse expanded tag list in edit mode

### DIFF
--- a/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
+++ b/imports/plugins/core/ui-tagnav/client/components/tagNav/tagNav.js
@@ -271,7 +271,11 @@ Template.tagNav.helpers({
       isSelected,
       className: "js-tagNav-item",
       onTagSelect(selectedTag) {
-        instance.state.set("selectedTag", selectedTag);
+        if (JSON.stringify(selectedTag) === JSON.stringify(instance.state.get("selectedTag"))){
+          instance.state.set("selectedTag", null);
+        } else {
+          instance.state.set("selectedTag", selectedTag);
+        }
       },
       ...TagNavHelpers
     };


### PR DESCRIPTION
allows to collapse the expanded tag list in edit mode by clicking the same button, which expands the list
straight forward solution