### PR TITLE
fixed cancel button on package disabling

### DIFF
--- a/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
+++ b/imports/plugins/core/layout/client/templates/layout/alerts/reactionAlerts.js
@@ -66,7 +66,11 @@ Object.assign(Alerts, {
       return swal({
         type: "info",
         ...titleOrOptions
-      }).then(messageOrCallback);
+      }).then((isConfirm) => {
+        if (isConfirm === true) {
+          messageOrCallback();
+        }
+      });
     }
 
     let title = titleOrOptions;
@@ -77,7 +81,11 @@ Object.assign(Alerts, {
       message,
       type: "info",
       ...options
-    }).then(callback);
+    }).then((isConfirm) => {
+      if (isConfirm === true) {
+        callback();
+      }
+    });
   },
 
   toast(message, type, options) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] Description explains the issue / use-case resolved
- [ ] Only contains code directly related to the issue
- [ ] Has tests.
- [ ] Has docs.
- [ ] Passes all tests
- [ ] Has been linted and follows the style guide

cancel button handling according to obsolete version of sweetalert2
https://github.com/limonte/sweetalert2/releases/tag/v4.0.0
Probably, it would be better to update npm dependency of sweetalert2 to v4+ with the code in this file.